### PR TITLE
Starts up server for integration tests automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ env:
 before_script:
   - npm install
 script:
-  - node dist/src/server.js &
   - npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Users RESTful API
-[![Build Status](https://travis-ci.org/josemigallas/users-api.svg?branch=master)](https://travis-ci.org/josemigallas/users-api)  
+[![Build Status](https://travis-ci.org/josemigallas/users-api.svg?branch=master)](https://travis-ci.org/josemigallas/users-api)
 
 This API allows all CRUDL operations over the dataset hosted in https://gist.githubusercontent.com/jasonmadigan/009c15b5dc4b4eccd32b/raw/34759c44e77d2f3515e20ed561cdd7a5e8345585/users.json.
 
@@ -21,17 +21,9 @@ $ npm run clean
 ```
 
 ## Test Suite
-Alongside unit tests, the suite also performs some testing over the API routes. For this, it is needed to start the app manually in development mode. Open a terminal and run:
+Alongside unit tests, the suite also performs some testing over the API routes. For this, all you have to do is:
 ```
-$ export ENV_NODE="development" && npm install && npm start
-```
-You should see this message:
-```
-Users API listening on port 3000 in development mode
-```
-Then, open a different terminal and simply run:
-```
-$ npm test
+$ export ENV_NODE="development" && npm install && npm test
 ```
 
 ## CI / CD

--- a/spec/routes/users.spec.ts
+++ b/spec/routes/users.spec.ts
@@ -29,6 +29,9 @@ describe("Route users", () => {
 
     beforeAll(() => {
         spyOnProperty(RealmHelper, "config", "get").and.returnValue(TEST_CONFIG);
+
+        // Starts the server in order to run integration tests
+        require("../../src/server");
     });
 
     beforeEach(() => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,5 +23,5 @@ import RealmHelper from "./repository/realm-helper";
 RealmHelper.init(mode);
 
 app.listen(port, () => {
-    console.log(`Users API v${process.env.npm_package_version} listening on port ${port} in ${process.env.ENV_NODE} mode`);
+    console.log(`Users API v${process.env.npm_package_version} listening on port ${port} in ${mode} mode`);
 });


### PR DESCRIPTION
This PR removes the need of starting the server as a background task before running the test suite, making it very easy to run them by simply issuing `$ npm test`.